### PR TITLE
Do not resample synthsr image

### DIFF
--- a/autoafids/workflow/Snakefile
+++ b/autoafids/workflow/Snakefile
@@ -228,7 +228,7 @@ rule norm_im:
         "scripts/norm_schemes.py"
 
 
-if "resample_im" in profile_settings:
+if "resample_im" in profile_settings and config["modality"] == "T1w":
 
     rule resample_im:
         input:


### PR DESCRIPTION
We do not need to resample SynthSR output image as it is 1 mm^3 already.